### PR TITLE
feat: add projects and technologies payload collections and portfolio views

### DIFF
--- a/src/app/(site)/globals.css
+++ b/src/app/(site)/globals.css
@@ -10,6 +10,8 @@
   --color-primary: #092E20;
   --color-secondary: #3776AB;
   --color-accent: #FFD43B;
+  --color-base-100: #ffffff;
+  --color-base-content: #171717;
 }
 
 :root {
@@ -20,9 +22,10 @@
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
+  --color-background: #ffffff;
+  --color-foreground: #171717;
 }
+
 
 body {
   background: var(--background);
@@ -36,4 +39,10 @@ main {
 
 .ops {
   font-family: var(--font-black_ops_one);
+}
+
+.btn:hover {
+  background-color: black !important;
+  color: white !important;
+  border-color: black !important;
 }

--- a/src/app/(site)/portfolio/[slug]/page.tsx
+++ b/src/app/(site)/portfolio/[slug]/page.tsx
@@ -1,0 +1,134 @@
+import { Metadata } from "next"
+import { notFound } from "next/navigation"
+import Image from "next/image"
+import Link from "next/link"
+import { getPayload } from "payload"
+import config from "@payload-config"
+import * as Icons from "@icons-pack/react-simple-icons"
+import { RichText } from '@payloadcms/richtext-lexical/react'
+
+import { Media, Technology } from "@/payload-types"
+import { PageTitle } from "@/components/ds/PageTitle"
+
+interface Props {
+    params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { slug } = await params
+    const payload = await getPayload({ config })
+    const result = await payload.find({
+        collection: 'projects',
+        where: { slug: { equals: slug } },
+        limit: 1,
+    })
+
+    const project = result.docs[0]
+
+    if (!project) {
+        return {
+            title: 'Project Not Found',
+        }
+    }
+
+    return {
+        title: `${project.name} | Portfolio`,
+        description: `Details about the ${project.name} project.`,
+    }
+}
+
+export default async function ProjectDetailPage({ params }: Props) {
+    const { slug } = await params
+    const payload = await getPayload({ config })
+    const result = await payload.find({
+        collection: 'projects',
+        where: { slug: { equals: slug } },
+        limit: 1,
+        depth: 2,
+    })
+
+    const project = result.docs[0]
+
+    if (!project) {
+        notFound()
+    }
+
+    return (
+        <main>
+            <PageTitle title={project.name} description="Project Details" />
+
+            <section className="py-16">
+                <div className="mx-auto max-w-md md:max-w-4xl lg:max-w-4xl bg-base-100 shadow-xl rounded-xl overflow-hidden p-6 md:p-10">
+
+                    <div className="mb-8">
+                        {project.thumbnail && typeof project.thumbnail !== 'string' ? (
+                            <Image
+                                src={(project.thumbnail as Media).url!}
+                                alt={project.name}
+                                width={800}
+                                height={400}
+                                className="w-full h-auto rounded-lg object-cover"
+                            />
+                        ) : (
+                            <div className="w-full h-[400px] bg-base-200 rounded-lg flex items-center justify-center">
+                                <span className="text-base-content/50">No Thumbnail Available</span>
+                            </div>
+                        )}
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8 border-b pb-8">
+                        <div className="md:col-span-2 prose max-w-none">
+                            <h2 className="text-2xl font-bold mb-4">About the Project</h2>
+                            {project.content && (
+                                <RichText data={project.content} />
+                            )}
+                        </div>
+
+                        <div className="space-y-6">
+                            <div>
+                                <h3 className="font-bold text-lg mb-2">Details</h3>
+                                {project.company && typeof project.company !== 'string' && (
+                                    <p className="mb-2">
+                                        <span className="font-semibold">Company:</span> {project.company.name}
+                                    </p>
+                                )}
+                                {project.public_link && (
+                                    <p>
+                                        <span className="font-semibold">Live Site:</span>{' '}
+                                        <a href={project.public_link} target="_blank" rel="noopener noreferrer" className="link link-primary">
+                                            Visit Link
+                                        </a>
+                                    </p>
+                                )}
+                            </div>
+
+                            <div>
+                                <h3 className="font-bold text-lg mb-2">Technologies Used</h3>
+                                <div className="flex flex-wrap gap-3">
+                                    {project.technologies?.map((techInput) => {
+                                        const tech = techInput as Technology
+                                        const IconComponent = tech.icon ? (Icons as any)[tech.icon] : null
+
+                                        return (
+                                            <div key={tech.id} className="flex items-center gap-2 bg-base-200 px-3 py-2 rounded-lg">
+                                                {IconComponent && <IconComponent size={20} />}
+                                                <span className="text-sm font-medium">{tech.name}</span>
+                                            </div>
+                                        )
+                                    })}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="text-center">
+                        <Link href="/portfolio" className="btn btn-outline">
+                            &larr; Back to Portfolio
+                        </Link>
+                    </div>
+
+                </div>
+            </section>
+        </main>
+    )
+}

--- a/src/app/(site)/portfolio/[slug]/page.tsx
+++ b/src/app/(site)/portfolio/[slug]/page.tsx
@@ -58,15 +58,15 @@ export default async function ProjectDetailPage({ params }: Props) {
             <PageTitle title={project.name} description="Project Details" />
 
             <section className="py-16">
-                <div className="mx-auto max-w-md md:max-w-4xl lg:max-w-4xl bg-base-100 shadow-xl rounded-xl overflow-hidden p-6 md:p-10">
+                <div className="mx-auto max-w-7xl px-6 md:px-10">
 
                     <div className="mb-8">
                         {project.thumbnail && typeof project.thumbnail !== 'string' ? (
                             <Image
                                 src={(project.thumbnail as Media).url!}
                                 alt={project.name}
-                                width={800}
-                                height={400}
+                                width={1200}
+                                height={600}
                                 className="w-full h-auto rounded-lg object-cover"
                             />
                         ) : (
@@ -76,8 +76,8 @@ export default async function ProjectDetailPage({ params }: Props) {
                         )}
                     </div>
 
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8 border-b pb-8">
-                        <div className="md:col-span-2 prose max-w-none">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-12 mb-8 border-b pb-8">
+                        <div className="md:col-span-2 prose max-w-none px-0">
                             <h2 className="text-2xl font-bold mb-4">About the Project</h2>
                             {project.content && (
                                 <RichText data={project.content} />
@@ -104,15 +104,15 @@ export default async function ProjectDetailPage({ params }: Props) {
 
                             <div>
                                 <h3 className="font-bold text-lg mb-2">Technologies Used</h3>
-                                <div className="flex flex-wrap gap-3">
+                                <div className="flex flex-wrap gap-4">
                                     {project.technologies?.map((techInput) => {
                                         const tech = techInput as Technology
                                         const IconComponent = tech.icon ? (Icons as any)[tech.icon] : null
 
                                         return (
-                                            <div key={tech.id} className="flex items-center gap-2 bg-base-200 px-3 py-2 rounded-lg">
-                                                {IconComponent && <IconComponent size={20} />}
-                                                <span className="text-sm font-medium">{tech.name}</span>
+                                            <div key={tech.id} className="flex items-center gap-2">
+                                                {IconComponent && <IconComponent size={24} />}
+                                                <span className="text-md font-medium text-black">{tech.name}</span>
                                             </div>
                                         )
                                     })}
@@ -120,6 +120,7 @@ export default async function ProjectDetailPage({ params }: Props) {
                             </div>
                         </div>
                     </div>
+
 
                     <div className="text-center">
                         <Link href="/portfolio" className="btn btn-outline">

--- a/src/app/(site)/portfolio/page.tsx
+++ b/src/app/(site)/portfolio/page.tsx
@@ -7,10 +7,15 @@ export const metadata : Metadata = {
   description: "Portfolio page",
 };
 
-export default function PortfolioPage() {
+interface Props {
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default async function PortfolioPage({ searchParams }: Props) {
+  const resolvedSearchParams = await searchParams;
   return (
     <main>
-      <PortfolioScreen />
+      <PortfolioScreen searchParams={resolvedSearchParams} />
     </main>
   );
 }

--- a/src/collections/Projects.ts
+++ b/src/collections/Projects.ts
@@ -1,0 +1,84 @@
+import type { CollectionConfig } from 'payload'
+import { lexicalEditor } from '@payloadcms/richtext-lexical'
+import { revalidatePath } from 'next/cache'
+
+export const Projects: CollectionConfig = {
+    slug: 'projects',
+    labels: {
+        singular: 'Project',
+        plural: 'Projects',
+    },
+    admin: {
+        useAsTitle: 'name',
+    },
+    access: {
+        read: () => true,
+    },
+    fields: [
+        {
+            name: 'name',
+            label: 'Project Name',
+            type: 'text',
+            required: true,
+        },
+        {
+            name: 'public_link',
+            label: 'Public Link',
+            type: 'text',
+            required: true,
+            admin: {
+                description: 'Must be a real link in production',
+            },
+        },
+        {
+            name: 'company',
+            label: 'Company',
+            type: 'relationship',
+            relationTo: 'companies',
+        },
+        {
+            name: 'technologies',
+            label: 'Technologies',
+            type: 'relationship',
+            relationTo: 'technologies',
+            hasMany: true,
+        },
+        {
+            name: 'thumbnail',
+            label: 'Thumbnail',
+            type: 'upload',
+            relationTo: 'media',
+        },
+        {
+            name: 'content',
+            label: 'Content',
+            type: 'richText',
+            editor: lexicalEditor(),
+        },
+        {
+            name: 'slug',
+            label: 'Slug',
+            type: 'text',
+            required: true,
+            unique: true,
+            admin: {
+                position: 'sidebar',
+            },
+        },
+    ],
+    hooks: {
+        afterChange: [
+            ({ doc }) => {
+                revalidatePath('/portfolio')
+                revalidatePath(`/portfolio/${doc.slug}`)
+                return doc
+            },
+        ],
+        afterDelete: [
+            ({ doc }) => {
+                revalidatePath('/portfolio')
+                return doc
+            },
+        ],
+    },
+}

--- a/src/collections/Projects.ts
+++ b/src/collections/Projects.ts
@@ -22,6 +22,18 @@ export const Projects: CollectionConfig = {
             required: true,
         },
         {
+            name: 'releaseDate',
+            label: 'Release Date',
+            type: 'date',
+            required: true,
+            admin: {
+                position: 'sidebar',
+                date: {
+                    pickerAppearance: 'dayAndTime',
+                },
+            },
+        },
+        {
             name: 'public_link',
             label: 'Public Link',
             type: 'text',
@@ -81,4 +93,5 @@ export const Projects: CollectionConfig = {
             },
         ],
     },
+    defaultSort: '-releaseDate',
 }

--- a/src/collections/Technologies.ts
+++ b/src/collections/Technologies.ts
@@ -1,0 +1,33 @@
+import type { CollectionConfig } from 'payload'
+
+export const Technologies: CollectionConfig = {
+    slug: 'technologies',
+    labels: {
+        singular: 'Technology',
+        plural: 'Technologies',
+    },
+    admin: {
+        useAsTitle: 'name',
+    },
+    access: {
+        read: () => true,
+    },
+    fields: [
+        {
+            name: 'name',
+            label: 'Name',
+            type: 'text',
+            required: true,
+        },
+        {
+            name: 'icon',
+            label: 'Icon (React Simple Icon name, e.g. SiReact)',
+            type: 'text',
+        },
+        {
+            name: 'description',
+            label: 'Description',
+            type: 'textarea',
+        },
+    ],
+}

--- a/src/components/ds/PageTitle/_PageTitle.tsx
+++ b/src/components/ds/PageTitle/_PageTitle.tsx
@@ -5,9 +5,11 @@ type Props = {
 
 export const PageTitle = ({ title, description }: Props) => {
   return (
-    <div className="pt-24 pb-12 px-10 bg-neutral text-neutral-content">
+    <div className="pt-32 pb-12 px-10 bg-black text-white">
+      <div className="max-w-7xl mx-auto">
         <h1 className="text-5xl font-bold">{title}</h1>
         {description && <p className="text-2xl mt-2">{description}</p>}
+      </div>
     </div>
   )
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -71,6 +71,8 @@ export interface Config {
     media: Media;
     companies: Company;
     'experience-details': ExperienceDetail;
+    technologies: Technology;
+    projects: Project;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -82,6 +84,8 @@ export interface Config {
     media: MediaSelect<false> | MediaSelect<true>;
     companies: CompaniesSelect<false> | CompaniesSelect<true>;
     'experience-details': ExperienceDetailsSelect<false> | ExperienceDetailsSelect<true>;
+    technologies: TechnologiesSelect<false> | TechnologiesSelect<true>;
+    projects: ProjectsSelect<false> | ProjectsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -222,6 +226,51 @@ export interface ExperienceDetail {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "technologies".
+ */
+export interface Technology {
+  id: string;
+  name: string;
+  icon?: string | null;
+  description?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "projects".
+ */
+export interface Project {
+  id: string;
+  name: string;
+  /**
+   * Must be a real link in production
+   */
+  public_link: string;
+  company?: (string | null) | Company;
+  technologies?: (string | Technology)[] | null;
+  thumbnail?: (string | null) | Media;
+  content?: {
+    root: {
+      type: string;
+      children: {
+        type: any;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  } | null;
+  slug: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -259,6 +308,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'experience-details';
         value: string | ExperienceDetail;
+      } | null)
+    | ({
+        relationTo: 'technologies';
+        value: string | Technology;
+      } | null)
+    | ({
+        relationTo: 'projects';
+        value: string | Project;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -371,6 +428,32 @@ export interface ExperienceDetailsSelect<T extends boolean = true> {
         achievement?: T;
         id?: T;
       };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "technologies_select".
+ */
+export interface TechnologiesSelect<T extends boolean = true> {
+  name?: T;
+  icon?: T;
+  description?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "projects_select".
+ */
+export interface ProjectsSelect<T extends boolean = true> {
+  name?: T;
+  public_link?: T;
+  company?: T;
+  technologies?: T;
+  thumbnail?: T;
+  content?: T;
+  slug?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -243,6 +243,7 @@ export interface Technology {
 export interface Project {
   id: string;
   name: string;
+  releaseDate: string;
   /**
    * Must be a real link in production
    */
@@ -448,6 +449,7 @@ export interface TechnologiesSelect<T extends boolean = true> {
  */
 export interface ProjectsSelect<T extends boolean = true> {
   name?: T;
+  releaseDate?: T;
   public_link?: T;
   company?: T;
   technologies?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -10,6 +10,8 @@ import { Users } from './collections/Users'
 import { Media } from './collections/Media'
 import { Companies } from './collections/Companies'
 import { ExperienceDetails } from './collections/ExperienceDetails'
+import { Technologies } from './collections/Technologies'
+import { Projects } from './collections/Projects'
 import { SiteSettings } from './globals/SiteSettings'
 import { envs } from './lib/envs'
 
@@ -23,7 +25,7 @@ export default buildConfig({
             baseDir: path.resolve(dirname),
         },
     },
-    collections: [Users, Media, Companies, ExperienceDetails],
+    collections: [Users, Media, Companies, ExperienceDetails, Technologies, Projects],
     globals: [SiteSettings],
     editor: lexicalEditor(),
     secret: envs.payloadSecret,

--- a/src/screens/Home/Contact/_Contact.tsx
+++ b/src/screens/Home/Contact/_Contact.tsx
@@ -149,7 +149,7 @@ export const Contact = ({ contactEmail, githubUser, linkedinUser, calendlyUser }
                   href={`https://github.com/${githubUser}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="btn btn-ghost border-2 border-gray-700 text-gray-300 hover:border-gray-500 hover:bg-gray-800 hover:text-white transition-all gap-2"
+                  className="btn btn-ghost border-2 border-gray-700 text-gray-300 transition-all gap-2"
                 >
                   <Github size={20} />
                   GitHub
@@ -158,7 +158,7 @@ export const Contact = ({ contactEmail, githubUser, linkedinUser, calendlyUser }
                   href={`https://linkedin.com/in/${linkedinUser}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="btn btn-ghost border-2 border-gray-700 text-gray-300 hover:border-blue-600 hover:bg-blue-600 hover:text-white transition-all gap-2"
+                  className="btn btn-ghost border-2 border-gray-700 text-gray-300 transition-all gap-2"
                 >
                   <Linkedin size={20} />
                   LinkedIn
@@ -167,7 +167,7 @@ export const Contact = ({ contactEmail, githubUser, linkedinUser, calendlyUser }
                   href={`https://calendly.com/${calendlyUser}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="btn btn-ghost border-2 border-gray-700 text-gray-300 hover:border-primary hover:bg-primary hover:text-white transition-all gap-2"
+                  className="btn btn-ghost border-2 border-gray-700 text-gray-300 transition-all gap-2"
                 >
                   <FontAwesomeIcon icon={faCalendarAlt} />
                   Schedule Call

--- a/src/screens/Home/Hero/_Hero.tsx
+++ b/src/screens/Home/Hero/_Hero.tsx
@@ -57,7 +57,7 @@ export const Hero = async () => {
               View My Work
               <ArrowRight size={20} />
             </a>
-            <a href="#contact" className="btn btn-outline btn-lg gap-2 text-gray-300 border-2 border-gray-500 hover:bg-gray-800 hover:border-gray-400 transition-all">
+            <a href="#contact" className="btn btn-outline btn-lg gap-2 text-gray-300 border-2 border-gray-500 transition-all">
               Get in Touch
               <Mail size={20} />
             </a>
@@ -69,7 +69,7 @@ export const Hero = async () => {
               href={`https://linkedin.com/in/${linkedin}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="btn btn-ghost gap-2 text-gray-300 border border-gray-700 hover:bg-[#0A66C2] hover:border-[#0A66C2] hover:text-white transition-all"
+              className="btn btn-ghost gap-2 text-gray-300 border border-gray-700 transition-all"
               aria-label="LinkedIn Profile"
             >
               <LinkedinPlain color="currentColor" size={24} />
@@ -79,7 +79,7 @@ export const Hero = async () => {
               href={`https://github.com/${github}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="btn btn-ghost gap-2 text-gray-300 border border-gray-700 hover:bg-[#6e5494] hover:border-[#6e5494] hover:text-white transition-all"
+              className="btn btn-ghost gap-2 text-gray-300 border border-gray-700 transition-all"
               aria-label="GitHub Profile"
             >
               <SiGithub size={24} />
@@ -89,7 +89,7 @@ export const Hero = async () => {
               href={`https://calendly.com/${calendly}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="btn btn-ghost gap-2 text-gray-300 border border-gray-700 hover:bg-[#006BFF] hover:border-[#006BFF] hover:text-white transition-all"
+              className="btn btn-ghost gap-2 text-gray-300 border border-gray-700 transition-all"
               aria-label="Schedule a Call"
             >
               <FontAwesomeIcon icon={faCalendarAlt} size="lg" />
@@ -97,7 +97,7 @@ export const Hero = async () => {
             </a>
             <a
               href={`mailto:${email}`}
-              className="btn btn-ghost gap-2 text-gray-300 border border-gray-700 hover:bg-[#14B8A6] hover:border-[#14B8A6] hover:text-white transition-all"
+              className="btn btn-ghost gap-2 text-gray-300 border border-gray-700 transition-all"
               aria-label="Send Email"
             >
               <Mail size={24} />

--- a/src/screens/Home/Portfolio/_Portfolio.tsx
+++ b/src/screens/Home/Portfolio/_Portfolio.tsx
@@ -103,7 +103,7 @@ export const Portfolio = async () => {
 
         {/* View All Projects CTA */}
         <div className="text-center mt-16">
-            <Link href="/portfolio" className="btn btn-outline btn-lg gap-2 text-gray-700 border-2 border-gray-400 hover:bg-gray-200 hover:border-gray-500 transition-all">
+            <Link href="/portfolio" className="btn btn-outline btn-lg gap-2 text-gray-700 border-2 border-gray-400 transition-all">
               View All Projects
               <ExternalLink size={20} />
             </Link>

--- a/src/screens/Home/Portfolio/_Portfolio.tsx
+++ b/src/screens/Home/Portfolio/_Portfolio.tsx
@@ -46,12 +46,11 @@ export const Portfolio = async () => {
               <article key={project.id} className="card bg-white border-2 border-gray-200 hover:border-gray-400 hover:shadow-xl transition-all">
                 <figure className="relative overflow-hidden h-48">
                   {project.thumbnail && typeof project.thumbnail !== 'string' ? (
-                     <Image
-                        src={(project.thumbnail as Media).url!}
-                        alt={project.name}
-                        fill
-                        className="object-cover"
-                     />
+                    <img
+                      src={(project.thumbnail as Media).url!}
+                      alt={project.name}
+                      className="object-cover h-full w-full"
+                    />
                   ) : (
                     <img
                       src="https://place-hold.it/400x250"

--- a/src/screens/Home/Portfolio/_Portfolio.tsx
+++ b/src/screens/Home/Portfolio/_Portfolio.tsx
@@ -1,19 +1,20 @@
-import {
-  SiReact,
-  SiTypescript,
-  SiWordpress,
-  SiJavascript,
-  SiVuedotjs,
-  SiPhp,
-  SiLaravel,
-  SiNodedotjs,
-  SiAwsfargate,
-  SiNextdotjs
-} from "@icons-pack/react-simple-icons";
 import { ExternalLink } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
+import { getPayload } from "payload"
+import config from "@payload-config"
+import * as Icons from "@icons-pack/react-simple-icons"
+import { Technology, Media } from "@/payload-types"
 
-export const Portfolio = () => {
+export const Portfolio = async () => {
+  const payload = await getPayload({ config })
+  const result = await payload.find({
+    collection: "projects",
+    depth: 2,
+    limit: 3,
+    sort: "-releaseDate",
+  })
+
   return (
     <section className="bg-gray-100 py-24 relative overflow-hidden" id="portfolio">
       {/* Background Pattern */}
@@ -38,139 +39,75 @@ export const Portfolio = () => {
         {/* Projects Grid */}
         <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
 
-          {/* Project Card 1 - Zigi App */}
-          <article className="card bg-white border-2 border-gray-200 hover:border-gray-400 hover:shadow-xl transition-all">
-            <figure className="relative overflow-hidden h-48">
-              <Image
-                src="/images/portfolio/zigi.png"
-                alt="Zigi App"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute top-4 right-4">
-                <span className="badge bg-gray-200 border-gray-300 text-gray-700">2023</span>
-              </div>
-            </figure>
+          {result.docs.map((project) => {
+             const releaseYear = project.releaseDate ? new Date(project.releaseDate).getFullYear() : ''
 
-            <div className="card-body">
-              <h3 className="card-title text-gray-900">Zigi App</h3>
-              <p className="text-gray-700">
-                Democratizing banking through fintech innovation. Mobile-first platform enabling financial access.
-              </p>
+             return (
+              <article key={project.id} className="card bg-white border-2 border-gray-200 hover:border-gray-400 hover:shadow-xl transition-all">
+                <figure className="relative overflow-hidden h-48">
+                  {project.thumbnail && typeof project.thumbnail !== 'string' ? (
+                     <Image
+                        src={(project.thumbnail as Media).url!}
+                        alt={project.name}
+                        fill
+                        className="object-cover"
+                     />
+                  ) : (
+                    <img
+                      src="https://place-hold.it/400x250"
+                      alt="Placeholder"
+                      className="object-cover h-full w-full"
+                    />
+                  )}
+                  {releaseYear && (
+                    <div className="absolute top-4 right-4">
+                      <span className="badge bg-gray-200 border-gray-300 text-gray-700">{releaseYear}</span>
+                    </div>
+                  )}
+                </figure>
 
-              <div className="my-4">
-                <p className="text-sm text-gray-500 mb-2">Tech Stack:</p>
-                <div className="flex flex-wrap gap-2">
-                  <SiReact size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#61DAFB' }} />
-                  <SiTypescript size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#3178C6' }} />
-                  <SiWordpress size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#21759B' }} />
+                <div className="card-body">
+                  <h3 className="card-title text-gray-900">{project.name}</h3>
+                  {project.company && typeof project.company !== 'string' && (
+                      <p className="text-gray-700">
+                         {project.company.name}
+                      </p>
+                  )}
+
+                  <div className="my-4">
+                    <p className="text-sm text-gray-500 mb-2">Tech Stack:</p>
+                    <div className="flex flex-wrap gap-2">
+                       {project.technologies?.map((techInput) => {
+                          const tech = techInput as Technology
+                          if (tech.icon) {
+                              const IconComponent = (Icons as any)[tech.icon]
+                              if (IconComponent) {
+                                  return <IconComponent key={tech.id} size={24} className="hover:scale-110 transition-all cursor-pointer" color="default" title={tech.name} />
+                              }
+                          }
+                          return <span key={tech.id} className="badge badge-neutral">{tech.name}</span>
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="card-actions justify-end mt-4">
+                    <Link href={`/portfolio/${project.slug}`} className="btn btn-sm btn-outline">
+                        See details
+                    </Link>
+                  </div>
                 </div>
-              </div>
-
-              {/* <div className="card-actions justify-start gap-2">
-                <a href="#" className="btn btn-sm btn-ghost text-gray-700 border border-gray-300 hover:border-gray-400 gap-2">
-                  <Github size={16} /> Code
-                </a>
-                <a href="#" className="btn btn-sm btn-ghost text-gray-700 border border-gray-300 hover:border-gray-400 gap-2">
-                  <ExternalLink size={16} /> Live
-                </a>
-              </div>*/}
-            </div>
-          </article>
-
-          {/* Project Card 2 - XP3 Talent */}
-          <article className="card bg-white border-2 border-gray-200 hover:border-gray-400 hover:shadow-xl transition-all">
-            <figure className="relative overflow-hidden h-48">
-              <Image
-                src="/images/portfolio/sescom.png"
-                alt="XP3 Talent"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute top-4 right-4">
-                <span className="badge bg-gray-200 border-gray-300 text-gray-700">2025</span>
-              </div>
-            </figure>
-
-            <div className="card-body">
-              <h3 className="card-title text-gray-900">SESCOM</h3>
-              <p className="text-gray-700">
-                Streamlining HR with intelligent automation. Comprehensive management system serving 500+ companies.
-              </p>
-
-              <div className="my-4">
-                <p className="text-sm text-gray-500 mb-2">Tech Stack:</p>
-                <div className="flex flex-wrap gap-2">
-                  <SiPhp size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#777BB4' }} />
-                  <SiLaravel size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#FF2D20' }} />
-                  <SiJavascript size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#F7DF1E' }} />
-                  <SiVuedotjs size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#4FC08D' }} />
-                  <SiAwsfargate size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#FF9900' }} />
-                </div>
-              </div>
-
-              {/* <div className="card-actions justify-start gap-2">
-                <a href="#" className="btn btn-sm btn-ghost text-gray-700 border border-gray-300 hover:border-gray-400 gap-2">
-                  <Github size={16} /> Code
-                </a>
-                <a href="#" className="btn btn-sm btn-ghost text-gray-700 border border-gray-300 hover:border-gray-400 gap-2">
-                  <ExternalLink size={16} /> Live
-                </a>
-              </div> */}
-            </div>
-          </article>
-
-          {/* Project Card 3 - Afinidata */}
-          <article className="card bg-white border-2 border-gray-200 hover:border-gray-400 hover:shadow-xl transition-all">
-            <figure className="relative overflow-hidden h-48">
-              <Image
-                src="/images/portfolio/insolgas.png"
-                alt="InsolGas"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute top-4 right-4">
-                <span className="badge bg-gray-200 border-gray-300 text-gray-700">2024</span>
-              </div>
-            </figure>
-
-            <div className="card-body">
-              <h3 className="card-title text-gray-900">InsolGas</h3>
-              <p className="text-gray-700">
-                Website for InsolGas, a company that provides instalation of gas stations and services.
-              </p>
-
-              <div className="my-4">
-                <p className="text-sm text-gray-500 mb-2">Tech Stack:</p>
-                <div className="flex flex-wrap gap-2">
-                  <SiNodedotjs size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#339933' }} />
-                  <SiTypescript size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#3178C6' }} />
-                  <SiReact size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#61DAFB' }} />
-                  <SiNextdotjs size={24} className="hover:scale-110 transition-all cursor-pointer" style={{ color: '#000000' }} />
-                </div>
-              </div>
-
-              {/* <div className="card-actions justify-start gap-2">
-                <a href="#" className="btn btn-sm btn-ghost text-gray-700 border border-gray-300 hover:border-gray-400 gap-2">
-                  <Github size={16} /> Code
-                </a>
-                <a href="#" className="btn btn-sm btn-ghost text-gray-700 border border-gray-300 hover:border-gray-400 gap-2">
-                  <ExternalLink size={16} /> Live
-                </a>
-              </div> */}
-            </div>
-          </article>
+              </article>
+             )
+          })}
 
         </div>
 
         {/* View All Projects CTA */}
         <div className="text-center mt-16">
-          <div className="tooltip tooltip-top" data-tip="Coming Soon">
-            <button className="btn btn-outline btn-lg gap-2 text-gray-700 border-2 border-gray-400 hover:bg-gray-200 hover:border-gray-500 transition-all">
+            <Link href="/portfolio" className="btn btn-outline btn-lg gap-2 text-gray-700 border-2 border-gray-400 hover:bg-gray-200 hover:border-gray-500 transition-all">
               View All Projects
               <ExternalLink size={20} />
-            </button>
-          </div>
+            </Link>
         </div>
       </div>
     </section>

--- a/src/screens/Portfolio/Content/_Content.tsx
+++ b/src/screens/Portfolio/Content/_Content.tsx
@@ -1,16 +1,20 @@
 import { Form } from "../Form"
 import { List } from "../List"
 
-export const Content = () => {
+interface Props {
+  searchParams?: { [key: string]: string | string[] | undefined };
+}
+
+export const Content = ({ searchParams }: Props) => {
   return (
     <section className="py-16">
       <div className="mx-auto max-w-md md:max-w-7xl lg:max-w-7xl">
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div>
             <Form />
           </div>
           <div className="col-span-2">
-            <List />
+            <List searchParams={searchParams} />
           </div>
         </div>
       </div>

--- a/src/screens/Portfolio/Form/_Form.tsx
+++ b/src/screens/Portfolio/Form/_Form.tsx
@@ -1,19 +1,56 @@
 'use client'
 
-import { useState, useId } from "react"
+import { useState, useEffect, useId, useCallback } from "react"
+import { useRouter, useSearchParams, usePathname } from "next/navigation"
+
+interface Tech {
+    id: string;
+    name: string;
+}
 
 export const Form = () => {
-  const [ items, setItems ] = useState<string[]>(['all'])
+  const [techs, setTechs] = useState<Tech[]>([])
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
   const formId = useId()
 
+  const fetchTechs = useCallback(async () => {
+    try {
+        const response = await fetch('/api/technologies?limit=100')
+        const data = await response.json()
+        setTechs(data.docs)
+    } catch (error) {
+        console.error('Error fetching technologies', error)
+    }
+  }, [])
+
+  useEffect(() => {
+      fetchTechs()
+  }, [fetchTechs])
+
+  const currentParams = new URLSearchParams(Array.from(searchParams.entries()))
+  const currentTechParams = currentParams.get('tech')
+  const items = currentTechParams ? currentTechParams.split(',') : []
+
   const toggleItem = (item: string) => {
-    setItems((prev) => {
-      if (prev.includes(item)) {
-        return prev.filter(i => i !== item)
-      } else {
-        return [...prev, item]
-      }
-    })
+    let newItems: string[]
+    if (items.includes(item)) {
+        newItems = items.filter(i => i !== item)
+    } else {
+        newItems = [...items, item]
+    }
+
+    if (newItems.length > 0) {
+        currentParams.set('tech', newItems.join(','))
+    } else {
+        currentParams.delete('tech')
+    }
+
+    // reset page to 1 when changing filters
+    currentParams.delete('page')
+
+    router.push(`${pathname}?${currentParams.toString()}`)
   }
 
   const checkIfItemChecked = (item: string) => {
@@ -21,287 +58,30 @@ export const Form = () => {
   }
  
   return (
-    <aside>
-      <p className="mb-2">Role:</p>
+    <aside className="sticky top-24 bg-base-100 p-4 rounded-lg shadow-sm">
+      <p className="mb-4 font-bold text-lg">Filters</p>
 
-      <form action="#">
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-all`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('all')} 
-              onChange={() => toggleItem('all')} 
-              className="checkbox checkbox-neutral" />{' '}
-            All
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-frontend`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('frontend')} 
-              onChange={() => toggleItem('frontend')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Frontend
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-backend`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('backend')} 
-              onChange={() => toggleItem('backend')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Backend
-          </label>
-        </fieldset>
-
-        <fieldset>
-          <label htmlFor={`${formId}-mobile`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('mobile')} 
-              onChange={() => toggleItem('mobile')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Mobile
-          </label>
-        </fieldset>
-
-        <div className="divider"></div>
-
-        <p className="mb-2">Languages:</p>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-javascript`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('javascript')} 
-              onChange={() => toggleItem('javascript')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Javascript
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-typescript`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('typescript')} 
-              onChange={() => toggleItem('typescript')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Typescript
-          </label>
-        </fieldset>
-
-        
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-python`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('python')} 
-              onChange={() => toggleItem('python')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Python
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-ruby`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('ruby')} 
-              onChange={() => toggleItem('ruby')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Ruby
-          </label>
-        </fieldset>
-
-        <fieldset>
-          <label htmlFor={`${formId}-php`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('php')} 
-              onChange={() => toggleItem('php')} 
-              className="checkbox checkbox-neutral" />{' '}
-            PHP
-          </label>
-        </fieldset>
-
-        <div className="divider"></div>
-
-        <p className="mb-2">Frameworks:</p>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-react`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('react')} 
-              onChange={() => toggleItem('react')} 
-              className="checkbox checkbox-neutral" />{' '}
-            React
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-react-native`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('react-native')} 
-              onChange={() => toggleItem('react-native')} 
-              className="checkbox checkbox-neutral" />{' '}
-            React Native
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-ionic`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('ionic')} 
-              onChange={() => toggleItem('ionic')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Ionic
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-electron`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('electron')} 
-              onChange={() => toggleItem('electron')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Electron
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-vue`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('vue')} 
-              onChange={() => toggleItem('vue')} 
-              className="checkbox checkbox-neutral" />{' '}
-          Vue
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-angular`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('angular')} 
-              onChange={() => toggleItem('angular')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Angular
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-flask`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('flask')} 
-              onChange={() => toggleItem('flask')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Flask
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-web2py`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('web2py')} 
-              onChange={() => toggleItem('web2py')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Web2py
-          </label>
-        </fieldset>        
- 
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-django`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('django')} 
-              onChange={() => toggleItem('django')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Django
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-ruby-on-rails`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('ruby-on-rails')} 
-              onChange={() => toggleItem('ruby-on-rails')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Ruby on Rails
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-laravel`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('laravel')} 
-              onChange={() => toggleItem('laravel')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Laravel
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-code-igniter`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('code-igniter')} 
-              onChange={() => toggleItem('code-igniter')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Code Igniter
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-wordpress`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('wordpress')} 
-              onChange={() => toggleItem('wordpress')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Wordpress
-          </label>
-        </fieldset>
-
-        <div className="divider"></div>
-
-        <p className="mb-2">Other:</p>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-redux`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('redux')} 
-              onChange={() => toggleItem('redux')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Redux
-          </label>
-        </fieldset>
-
-        <fieldset className="mb-1">
-          <label htmlFor={`${formId}-mobx`}>
-            <input 
-              type="checkbox" 
-              checked={checkIfItemChecked('mobx')} 
-              onChange={() => toggleItem('mobx')} 
-              className="checkbox checkbox-neutral" />{' '}
-            Mobx
-          </label>
-        </fieldset>
-      </form>
+      <p className="mb-2 font-semibold">Technologies:</p>
+      {techs.length === 0 ? (
+          <span className="loading loading-spinner loading-sm"></span>
+      ) : (
+        <form action="#">
+            {techs.map((tech) => (
+                <fieldset className="mb-2" key={tech.id}>
+                    <label htmlFor={`${formId}-${tech.name}`} className="flex items-center gap-2 cursor-pointer">
+                        <input
+                            id={`${formId}-${tech.name}`}
+                            type="checkbox"
+                            checked={checkIfItemChecked(tech.name)}
+                            onChange={() => toggleItem(tech.name)}
+                            className="checkbox checkbox-sm checkbox-neutral"
+                        />
+                        <span className="label-text">{tech.name}</span>
+                    </label>
+                </fieldset>
+            ))}
+        </form>
+      )}
     </aside>
   )
 }

--- a/src/screens/Portfolio/Form/index.ts
+++ b/src/screens/Portfolio/Form/index.ts
@@ -1,1 +1,1 @@
-export * from './_Form';
+export { Form } from "./_Form"

--- a/src/screens/Portfolio/List/_List.tsx
+++ b/src/screens/Portfolio/List/_List.tsx
@@ -1,261 +1,118 @@
-import { 
-  SiAwsfargate, 
-  SiBitrise,
-  SiDjango,
-  SiExpress,
-  SiJavascript,
-  SiLaravel,
-  SiMessenger,
-  SiMobx,
-  SiNodedotjs,
-  SiPhp,
-  SiPython,
-  SiReact,
-  SiTwilio,
-  SiTypescript,
-  SiVuedotjs,
-  SiWordpress,
-  SiAurelia,
-  SiAngular,
-  SiIonic,
-  SiCodeigniter,
-  SiElectron,
-  SiNestjs,
-  SiNatsdotio,
-  SiMongodb,
-} from "@icons-pack/react-simple-icons"
+import Image from "next/image"
+import Link from "next/link"
+import { getPayload } from "payload"
+import config from "@payload-config"
+import * as Icons from "@icons-pack/react-simple-icons"
+import { Technology, Media } from "@/payload-types"
 
+interface Props {
+  searchParams?: { [key: string]: string | string[] | undefined };
+}
 
-export const List = () => {
+export const List = async ({ searchParams }: Props) => {
+  const payload = await getPayload({ config })
+  const page = typeof searchParams?.page === 'string' ? parseInt(searchParams.page, 10) : 1
+
+  const techFilters = searchParams?.tech
+  let techs: string[] = []
+  if (Array.isArray(techFilters)) {
+      techs = techFilters
+  } else if (typeof techFilters === 'string') {
+      techs = techFilters.split(',')
+  }
+
+  let where = {}
+  if (techs.length > 0) {
+      where = {
+          'technologies.name': {
+              in: techs
+          }
+      }
+  }
+
+  const result = await payload.find({
+    collection: "projects",
+    depth: 2,
+    page,
+    limit: 10,
+    where,
+  })
+
   return (
     <section>
+      {result.docs.length === 0 && (
+          <p>No projects found matching the selected filters.</p>
+      )}
 
-      <article className="card lg:card-side bg-base-100 shadow-sm mb-4">
-        <figure>
-          <img
-            src="https://place-hold.it/400x250"
-            alt="Album" />
-        </figure>
-        <div className="card-body">
-          <h2 className="card-title">{"T'Picaste"} App</h2>
-          <p>Fidelity App for small and medium business (In progress)</p>
-          <strong>Stack: </strong>
-          <p className="flex">
-            <SiReact className="mr-2" color="default" />
-            <SiTypescript className="mr-2" color="default" />
-            <SiNestjs color="default" className="mr-2" />
-            <SiMongodb className="mr-2" color="default" />
-            <SiNatsdotio className="mr-2" color="default" />
-          </p>
-          <div className="card-actions justify-end">
-            <button className="btn btn-neutral">See more</button>
-          </div>
+      {result.docs.map((project) => {
+        return (
+          <article key={project.id} className="card lg:card-side bg-base-100 shadow-sm mb-4">
+            <figure className="relative min-w-[400px]">
+              {project.thumbnail && typeof project.thumbnail !== 'string' ? (
+                 <Image
+                    src={(project.thumbnail as Media).url!}
+                    alt={project.name}
+                    width={400}
+                    height={250}
+                    className="object-cover h-full"
+                 />
+              ) : (
+                <img
+                  src="https://place-hold.it/400x250"
+                  alt="Placeholder"
+                  className="object-cover h-full"
+                />
+              )}
+            </figure>
+            <div className="card-body">
+              <h2 className="card-title">{project.name}</h2>
+              {project.company && typeof project.company !== 'string' && (
+                  <p className="text-sm text-gray-500">{project.company.name}</p>
+              )}
+
+              <strong className="mt-4">Stack: </strong>
+              <div className="flex flex-wrap gap-2">
+                {project.technologies?.map((techInput) => {
+                    const tech = techInput as Technology
+                    if (tech.icon) {
+                        const IconComponent = (Icons as any)[tech.icon]
+                        if (IconComponent) {
+                            return <IconComponent key={tech.id} color="default" title={tech.name} />
+                        }
+                    }
+                    return <span key={tech.id} className="badge badge-neutral">{tech.name}</span>
+                })}
+              </div>
+              <div className="card-actions justify-end mt-4">
+                <Link href={`/portfolio/${project.slug}`} className="btn btn-neutral">
+                    See more
+                </Link>
+              </div>
+            </div>
+          </article>
+        )
+      })}
+
+      {result.totalPages > 1 && (
+        <div className="join mt-8 flex justify-center">
+            {Array.from({ length: result.totalPages }).map((_, i) => {
+                const pageNum = i + 1
+                const query = new URLSearchParams()
+                if (techs.length > 0) query.set('tech', techs.join(','))
+                query.set('page', pageNum.toString())
+
+                return (
+                    <Link
+                        key={pageNum}
+                        href={`/portfolio?${query.toString()}`}
+                        className={`join-item btn ${pageNum === result.page ? 'btn-active' : ''}`}
+                    >
+                        {pageNum}
+                    </Link>
+                )
+            })}
         </div>
-      </article>
-
-      <article className="card lg:card-side bg-base-100 shadow-sm mb-4">
-        <figure>
-          <img
-            src="https://place-hold.it/400x250"
-            alt="Album" />
-        </figure>
-        <div className="card-body">
-          <h2 className="card-title">Zigi App</h2>
-          <p>Fintech app to democratize the banking.</p>
-          <strong>Stack: </strong>
-          <p className="flex">
-            <SiReact className="mr-2" color="default" />
-            <SiTypescript className="mr-2" color="default" />
-            <SiMobx className="mr-2" color="default" />
-            <SiBitrise className="mr-2" color="default" />
-            <SiWordpress color="default" />
-          </p>
-          <div className="card-actions justify-end">
-            <button className="btn btn-neutral">See more</button>
-          </div>
-        </div>
-      </article>
-
-      <article className="card lg:card-side bg-base-100 shadow-sm mb-4">
-        <figure>
-          <img
-            src="https://place-hold.it/400x250"
-            alt="Album" />
-        </figure>
-        <div className="card-body">
-          <h2 className="card-title">XP3 Talent</h2>
-          <p>Human resources web app.</p>
-          <strong>Stack: </strong>
-          <div className="flex">
-            <SiPhp className="mr-2" color="default" />
-            <SiLaravel className="mr-2" color="default" />
-            <SiJavascript className="mr-2" color="default" />
-            <SiVuedotjs className="mr-2" color="default" />
-            <SiAwsfargate color="default" />
-          </div>
-          <div className="card-actions justify-end">
-            <button className="btn btn-neutral">See more</button>
-          </div>
-        </div>
-      </article>
-
-      <article className="card lg:card-side bg-base-100 shadow-sm mb-4">
-        <figure>
-          <img
-            src="https://place-hold.it/400x250"
-            alt="Album" />
-        </figure>
-        <div className="card-body">
-          <h2 className="card-title">Afinidata</h2>
-          <p>Chatbot for first childhood development</p>
-          <strong>Stack: </strong>
-          <div className="flex">
-            <SiPython className="mr-2" color="default" />
-            <SiDjango className="mr-2" color="default" />
-            <SiNodedotjs className="mr-2" color="default" />
-            <SiExpress className="mr-2" color="default" />
-            <SiJavascript className="mr-2" color="default" />
-            <SiReact className="mr-2" color="default" />
-            <SiVuedotjs className="mr-2" color="default" />
-            <SiMessenger className="mr-2" color="default" />
-            <SiTwilio className="mr-2" color="default" />
-          </div>
-          <div className="card-actions justify-end">
-            <button className="btn btn-neutral">See more</button>
-          </div>
-        </div>
-      </article>
-
-      <article className="card lg:card-side bg-base-100 shadow-sm mb-4">
-        <figure>
-          <img
-            src="https://place-hold.it/400x250"
-            alt="Album" />
-        </figure>
-        <div className="card-body">
-          <h2 className="card-title">Botpro</h2>
-          <p>Chatbot BaaS platform</p>
-          <strong>Stack: </strong>
-          <div className="flex">
-            <SiPython className="mr-2" color="default" />
-            <SiJavascript className="mr-2" color="default" />
-            <SiAurelia className="mr-2" color="default" />
-            <SiMessenger className="mr-2" color="default" />
-
-          </div>
-          <div className="card-actions justify-end">
-            <button className="btn btn-neutral">See more</button>
-          </div>
-        </div>
-      </article>
-
-      <article className="card lg:card-side bg-base-100 shadow-sm mb-4">
-        <figure>
-          <img
-            src="https://place-hold.it/400x250"
-            alt="Album" />
-        </figure>
-        <div className="card-body">
-          <h2 className="card-title">Claro Fanáticos</h2>
-          <p>Oficial Sports app for Claro Guatemala</p>
-          <strong>Stack: </strong>
-          <div className="flex">
-            <SiJavascript className="mr-2" color="default" />
-            <SiAngular className="mr-2" color="default" />
-            <SiIonic className="mr-2" color="default" />
-          </div>
-          <div className="card-actions justify-end">
-            <button className="btn btn-neutral">See more</button>
-          </div>
-        </div>
-      </article>
-
-      
-      <article className="card lg:card-side bg-base-100 shadow-sm mb-4">
-        <figure>
-          <img
-            src="https://place-hold.it/400x250"
-            alt="Album" />
-        </figure>
-        <div className="card-body">
-          <h2 className="card-title">La Hora</h2>
-          <p>Website and App for a news company in Guatemala</p>
-          <strong>Stack: </strong>
-          <div className="flex">
-            <SiJavascript className="mr-2" color="default" />
-            <SiReact className="mr-2" color="default" />
-            <SiPhp className="mr-2" color="default" />
-            <SiWordpress className="mr-2" color="default" />
-          </div>
-          <div className="card-actions justify-end">
-            <button className="btn btn-neutral">See more</button>
-          </div>
-        </div>
-      </article>
-
-      <article className="card lg:card-side bg-base-100 shadow-sm mb-4">
-        <figure>
-          <img
-            src="https://place-hold.it/400x250"
-            alt="Album" />
-        </figure>
-        <div className="card-body">
-          <h2 className="card-title">Tyto</h2>
-          <p>Cloud platform for legal documents, App and Desktop App</p>
-          <strong>Stack: </strong>
-          <div className="flex">
-            <SiJavascript className="mr-2" color="default" />
-            <SiAngular className="mr-2" color="default" />
-            <SiIonic className="mr-2" color="default" />
-            <SiPhp className="mr-2" color="default" />
-            <SiCodeigniter className="mr-2" color="default" />
-            <SiElectron className="mr-2" color="default" />
-          </div>
-          <div className="card-actions justify-end">
-            <button className="btn btn-neutral">See more</button>
-          </div>
-        </div>
-      </article>
-
-      <article className="card lg:card-side bg-base-100 shadow-sm mb-4">
-        <figure>
-          <img
-            src="https://place-hold.it/400x250"
-            alt="Album" />
-        </figure>
-        <div className="card-body">
-          <h2 className="card-title">Ibagari Hotel</h2>
-          <p>Website for a luxury hotel in Roatan</p>
-          <strong>Stack: </strong>
-          <div className="flex">
-            <SiPhp className="mr-2" color="default" />
-            <SiWordpress className="mr-2" color="default" />
-          </div>
-          <div className="card-actions justify-end">
-            <button className="btn btn-neutral">See more</button>
-          </div>
-        </div>
-      </article>
-
-      <article className="card lg:card-side bg-base-100 shadow-sm mb-4">
-        <figure>
-          <img
-            src="https://place-hold.it/400x250"
-            alt="Album" />
-        </figure>
-        <div className="card-body">
-          <h2 className="card-title">Amigo Paisano</h2>
-          <p>Expectative website for the project</p>
-          <strong>Stack: </strong>
-          <div className="flex">
-            <SiJavascript className="mr-2" color="default" />
-            <SiReact className="mr-2" color="default" />
-          </div>
-          <div className="card-actions justify-end">
-            <button className="btn btn-neutral">See more</button>
-          </div>
-        </div>
-      </article>
+      )}
     </section>
   )
 }

--- a/src/screens/Portfolio/List/index.ts
+++ b/src/screens/Portfolio/List/index.ts
@@ -1,1 +1,1 @@
-export * from './_List';
+export { List } from "./_List"

--- a/src/screens/Portfolio/PortfolioScreen.tsx
+++ b/src/screens/Portfolio/PortfolioScreen.tsx
@@ -1,11 +1,15 @@
 import { PageTitle } from "@/components/ds/PageTitle"
 import { Content } from "./Content"
 
-export const PortfolioScreen = () => {
+interface Props {
+  searchParams?: { [key: string]: string | string[] | undefined };
+}
+
+export const PortfolioScreen = ({ searchParams }: Props) => {
   return (
     <>
       <PageTitle title="Portfolio" description="Some of my projects" />
-      <Content />
+      <Content searchParams={searchParams} />
     </>
   )
 }


### PR DESCRIPTION
This PR adds the necessary Payload CMS collections and Next.js frontend logic to manage and display a portfolio of projects.

### Changes Made
1. **Payload CMS Collections:**
   - Created the `Projects` collection with fields: `name`, `public_link`, `company` (relationship), `thumbnail` (media), `content` (Lexical Rich Text), `technologies` (relationship), and a `slug`.
   - Created the `Technologies` collection with fields: `name`, `icon` (React Simple Icon string identifier), and `description`.
   - Registered the new collections in `payload.config.ts` and successfully generated the new types (`npm run generate:types`).
   - Added `revalidatePath` hooks on the `Projects` collection to update the frontend cache automatically upon changes.

2. **Frontend Views:**
   - Updated the main portfolio list view (`src/screens/Portfolio/List/_List.tsx`) to dynamically fetch projects from the local Payload API.
   - Added standard URL search parameter-based pagination and filtering.
   - Updated the sidebar filter (`src/screens/Portfolio/Form/_Form.tsx`) to dynamically fetch the list of available technologies and sync checkbox changes with the URL search parameters (`?tech=React,Node.js`).
   - Added a project detail page (`src/app/(site)/portfolio/[slug]/page.tsx`) that fetches a project by its slug. It displays the thumbnail, company name, live link, dynamically rendered technology icons using `@icons-pack/react-simple-icons`, and rich text content rendered using the Payload Lexical React component.

### Verification
- Ran standard codebase type generation locally.
- Verified all the Next.js `params` and `searchParams` are correctly resolved as Promises in Next.js 15.
- Simulated build steps and code reviews which successfully passed.

---
*PR created automatically by Jules for task [4446994961152930958](https://jules.google.com/task/4446994961152930958) started by @AleejandroReyna*