### PR TITLE
feat: auto-generate slug with underscores and revalidate root path

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,23 @@
+# Plan
+
+1. **Revalidate root path (`/`) on every collection update:**
+   - Update all `src/collections/*.ts` files to include hooks:
+     - For `Companies.ts`, `ExperienceDetails.ts`, `Media.ts`, `Projects.ts`, `Technologies.ts`, `Users.ts`:
+     - Add `afterChange` and `afterDelete` hooks to call `revalidatePath('/', 'layout')` (or standard `revalidatePath('/')` and `revalidatePath('/portfolio')` where appropriate). The prompt asks to "revalidate the root path for getting updates" when *every* payload collection is updated.
+
+2. **Custom auto-generating Slug field:**
+   - Create `src/components/ui/SlugField.tsx` which will be a custom Payload component.
+     - It will render an input.
+     - The input should have a locked/unlocked state via a button next to it.
+     - It should auto-generate the slug based on a specified field (e.g., `name` or `title`) replacing spaces with dashes and formatting securely (e.g., lowercase, removing special characters).
+     - The auto-generation could also append a random string or "scores instead of empty spaces". Wait, the prompt says "component slug will be auto generated adding scores instead of empty spaces" -> likely means "adding underscores instead of empty spaces". "scores" -> underscores (`_`). Wait, "adding scores instead of empty spaces". Could it mean `scores` instead of empty spaces? Or just underscores `_`? "adding underscores instead of empty spaces" is standard. I'll use `_`.
+     - "Input for slug will be disabled and blocked, there will be a button to unlock the input for editting manually."
+
+3. **Applying the Slug field to every collection:**
+   - "make that for every collection". So we should add a `slug` field to *every* collection if it doesn't already have one, and configure it to use the new custom component.
+   - Collections: `Companies`, `ExperienceDetails`, `Media`, `Projects`, `Technologies`, `Users`.
+   - Update the schema to include `slug: { type: 'text', unique: true, admin: { components: { Field: '@/components/ui/SlugField' } } }`. Note: The actual path might differ and we need to export it correctly for payload component resolving.
+   - I will define a reusable function to get the slug field configuration to avoid repetition.
+
+4. **Pre-commit Steps:**
+   - Ensure proper testing, verification, review, and reflection are done before submitting.

--- a/src/collections/Companies.ts
+++ b/src/collections/Companies.ts
@@ -1,4 +1,6 @@
 import type { CollectionConfig } from 'payload'
+import { revalidatePath } from 'next/cache'
+import { slugField } from '@/fields/slug'
 
 export const Companies: CollectionConfig = {
     slug: 'companies',
@@ -34,5 +36,20 @@ export const Companies: CollectionConfig = {
                 description: 'Company website URL',
             },
         },
+        slugField('name'),
     ],
+    hooks: {
+        afterChange: [
+            ({ doc }) => {
+                revalidatePath('/', 'layout')
+                return doc
+            },
+        ],
+        afterDelete: [
+            ({ doc }) => {
+                revalidatePath('/', 'layout')
+                return doc
+            },
+        ],
+    },
 }

--- a/src/collections/ExperienceDetails.ts
+++ b/src/collections/ExperienceDetails.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from 'payload'
 import { revalidatePath } from 'next/cache'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
+import { slugField } from '@/fields/slug'
 
 export const ExperienceDetails: CollectionConfig = {
     slug: 'experience-details',
@@ -91,17 +92,18 @@ export const ExperienceDetails: CollectionConfig = {
                 },
             ],
         },
+        slugField('role'),
     ],
     hooks: {
         afterChange: [
             ({ doc }) => {
-                revalidatePath('/')
+                revalidatePath('/', 'layout')
                 return doc
             },
         ],
         afterDelete: [
             ({ doc }) => {
-                revalidatePath('/')
+                revalidatePath('/', 'layout')
                 return doc
             },
         ],

--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -1,4 +1,6 @@
 import type { CollectionConfig } from 'payload'
+import { revalidatePath } from 'next/cache'
+import { slugField } from '@/fields/slug'
 
 export const Media: CollectionConfig = {
     slug: 'media',
@@ -11,8 +13,23 @@ export const Media: CollectionConfig = {
             type: 'text',
             required: true,
         },
+        slugField('alt'),
     ],
     upload: {
         disableLocalStorage: true,
+    },
+    hooks: {
+        afterChange: [
+            ({ doc }) => {
+                revalidatePath('/', 'layout')
+                return doc
+            },
+        ],
+        afterDelete: [
+            ({ doc }) => {
+                revalidatePath('/', 'layout')
+                return doc
+            },
+        ],
     },
 }

--- a/src/collections/Projects.ts
+++ b/src/collections/Projects.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig } from 'payload'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import { revalidatePath } from 'next/cache'
+import { slugField } from '@/fields/slug'
 
 export const Projects: CollectionConfig = {
     slug: 'projects',
@@ -67,27 +68,22 @@ export const Projects: CollectionConfig = {
             type: 'richText',
             editor: lexicalEditor(),
         },
-        {
-            name: 'slug',
-            label: 'Slug',
-            type: 'text',
-            required: true,
-            unique: true,
-            admin: {
-                position: 'sidebar',
-            },
-        },
+        slugField('name'),
     ],
     hooks: {
         afterChange: [
             ({ doc }) => {
+                revalidatePath('/', 'layout')
                 revalidatePath('/portfolio')
-                revalidatePath(`/portfolio/${doc.slug}`)
+                if (doc.slug) {
+                    revalidatePath(`/portfolio/${doc.slug}`)
+                }
                 return doc
             },
         ],
         afterDelete: [
             ({ doc }) => {
+                revalidatePath('/', 'layout')
                 revalidatePath('/portfolio')
                 return doc
             },

--- a/src/collections/Technologies.ts
+++ b/src/collections/Technologies.ts
@@ -1,4 +1,6 @@
 import type { CollectionConfig } from 'payload'
+import { revalidatePath } from 'next/cache'
+import { slugField } from '@/fields/slug'
 
 export const Technologies: CollectionConfig = {
     slug: 'technologies',
@@ -29,5 +31,20 @@ export const Technologies: CollectionConfig = {
             label: 'Description',
             type: 'textarea',
         },
+        slugField('name'),
     ],
+    hooks: {
+        afterChange: [
+            ({ doc }) => {
+                revalidatePath('/', 'layout')
+                return doc
+            },
+        ],
+        afterDelete: [
+            ({ doc }) => {
+                revalidatePath('/', 'layout')
+                return doc
+            },
+        ],
+    },
 }

--- a/src/collections/Users.ts
+++ b/src/collections/Users.ts
@@ -1,4 +1,6 @@
 import type { CollectionConfig } from 'payload'
+import { revalidatePath } from 'next/cache'
+import { slugField } from '@/fields/slug'
 
 export const Users: CollectionConfig = {
     slug: 'users',
@@ -8,6 +10,20 @@ export const Users: CollectionConfig = {
     auth: true,
     fields: [
         // Email added by default
-        // Add more fields as needed
+        slugField('email'),
     ],
+    hooks: {
+        afterChange: [
+            ({ doc }) => {
+                revalidatePath('/', 'layout')
+                return doc
+            },
+        ],
+        afterDelete: [
+            ({ doc }) => {
+                revalidatePath('/', 'layout')
+                return doc
+            },
+        ],
+    },
 }

--- a/src/components/SlugComponent.tsx
+++ b/src/components/SlugComponent.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { useFormFields, useField, TextInput } from '@payloadcms/ui'
+import { Lock, Unlock } from 'lucide-react'
+
+export const SlugComponent: React.FC<any> = ({ path, label, required }) => {
+    const { value, setValue } = useField<string>({ path })
+    const [isLocked, setIsLocked] = useState(true)
+
+    const nameField = useFormFields(([fields]) => fields.name?.value as string)
+    const titleField = useFormFields(([fields]) => fields.title?.value as string)
+    const roleField = useFormFields(([fields]) => fields.role?.value as string)
+    const emailField = useFormFields(([fields]) => fields.email?.value as string)
+    const altField = useFormFields(([fields]) => fields.alt?.value as string)
+
+    const fallbackValue = nameField || titleField || roleField || emailField || altField
+
+    const formatSlug = (val: string) =>
+        val
+            .replace(/\s+/g, '_')
+            .replace(/[^\w-]+/g, '')
+            .toLowerCase()
+
+    useEffect(() => {
+        if (isLocked && fallbackValue) {
+            const newSlug = formatSlug(fallbackValue)
+            if (newSlug !== value) {
+                setValue(newSlug)
+            }
+        }
+    }, [isLocked, fallbackValue, value, setValue])
+
+    return (
+        <div style={{ marginBottom: '1rem' }}>
+            <label className="field-label" style={{ display: 'block', marginBottom: '0.5rem' }}>
+                {label} {required && <span style={{ color: 'red' }}>*</span>}
+            </label>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <div style={{ flexGrow: 1 }}>
+                    <TextInput
+                        path={path}
+                        value={value || ''}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+                        readOnly={isLocked}
+                    />
+                </div>
+                <button
+                    type="button"
+                    onClick={() => setIsLocked(!isLocked)}
+                    style={{
+                        padding: '0.5rem',
+                        cursor: 'pointer',
+                        border: '1px solid #ccc',
+                        background: '#fff',
+                        borderRadius: '4px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        color: 'black'
+                    }}
+                    title={isLocked ? 'Unlock to edit' : 'Lock to auto-generate'}
+                >
+                    {isLocked ? <Lock size={16} /> : <Unlock size={16} />}
+                </button>
+            </div>
+            {isLocked && (
+                <p style={{ fontSize: '0.8rem', color: '#666', marginTop: '0.25rem' }}>
+                    Auto-generated. Unlock to edit manually.
+                </p>
+            )}
+        </div>
+    )
+}
+
+export default SlugComponent

--- a/src/fields/slug.ts
+++ b/src/fields/slug.ts
@@ -1,0 +1,22 @@
+import type { Field } from 'payload'
+import { formatSlug } from '@/utils/formatSlug'
+
+export const slugField = (fieldToUse: string = 'name'): Field => ({
+    name: 'slug',
+    label: 'Slug',
+    type: 'text',
+    required: true,
+    unique: true,
+    index: true,
+    admin: {
+        position: 'sidebar',
+        components: {
+            Field: '@/components/SlugComponent',
+        },
+    },
+    hooks: {
+        beforeValidate: [
+            formatSlug(fieldToUse),
+        ],
+    },
+})

--- a/src/utils/formatSlug.ts
+++ b/src/utils/formatSlug.ts
@@ -1,0 +1,22 @@
+import type { FieldHook } from 'payload'
+
+export const format = (val: string): string =>
+    val
+        .replace(/\s+/g, '_')
+        .replace(/[^\w-]+/g, '')
+        .toLowerCase()
+
+export const formatSlug =
+    (fallback: string): FieldHook =>
+    ({ value, originalDoc, data }) => {
+        if (typeof value === 'string' && value.length > 0) {
+            return format(value)
+        }
+        const fallbackData = data?.[fallback] || originalDoc?.[fallback]
+
+        if (fallbackData && typeof fallbackData === 'string') {
+            return format(fallbackData)
+        }
+
+        return value
+    }

--- a/test-db.ts
+++ b/test-db.ts
@@ -1,0 +1,2 @@
+import mongoose from 'mongoose';
+mongoose.connect('mongodb://localhost:27017/test').catch(console.error);

--- a/test-payload-ui.ts
+++ b/test-payload-ui.ts
@@ -1,0 +1,2 @@
+import { useField, useFormFields } from '@payloadcms/ui'
+console.log(!!useField, !!useFormFields)


### PR DESCRIPTION
This commit updates all Payload collections to revalidate the root path (`/`) when documents are created, updated, or deleted, ensuring the frontend always stays up to date. It also introduces a custom auto-generating slug component that replaces empty spaces with underscores (`_`) based on a configured fallback field (e.g., name, role, email). The slug field is rendered as a blocked/disabled input with a lock toggle button to enable manual editing, improving the editor experience.

---
*PR created automatically by Jules for task [6308665770274892595](https://jules.google.com/task/6308665770274892595) started by @AleejandroReyna*